### PR TITLE
Hide scrollbars when content collapsed

### DIFF
--- a/css/leaflet-sidebar.css
+++ b/css/leaflet-sidebar.css
@@ -64,6 +64,9 @@
   background-color: rgba(255, 255, 255, 0.95);
   overflow-x: hidden;
   overflow-y: auto; }
+  
+  .collapsed > .sidebar-content{
+    overflow-y:hidden;}
 
 .sidebar-pane {
   display: none;

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -124,6 +124,10 @@ $move-map-in-xs: true !default;
     overflow-y: auto;
 }
 
+ .collapsed > .sidebar-content {
+    overflow-y:hidden; }
+
+
 .sidebar-pane {
     display: none;
 


### PR DESCRIPTION
I have noticed in chrome when testing for several mobile browsers that when there is overflow content inside a pane when the sidebar is collapsed that  the scrollbar remains visible for the active pane and it gets placed above the buttons.  This small change forces the scrollbar to hide when the sidebar is collapsed.