### PR TITLE
 Adding tab-closed event

### DIFF
--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -136,7 +136,7 @@ L.Control.Sidebar = L.Control.extend({
                 L.DomUtil.removeClass(child, 'active');
         }
 
-        this.fire('tab-opened', { id: id });
+        this.fire('content tab-opened', { id: id });
 
         // open sidebar (if necessary)
         if (L.DomUtil.hasClass(this._sidebar, 'collapsed')) {

--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -121,8 +121,10 @@ L.Control.Sidebar = L.Control.extend({
             child = this._panes[i];
             if (child.id == id)
                 L.DomUtil.addClass(child, 'active');
-            else if (L.DomUtil.hasClass(child, 'active'))
+            else if (L.DomUtil.hasClass(child, 'active')) {
                 L.DomUtil.removeClass(child, 'active');
+                this.fire('tab-closed', {id: child.id });
+            }
         }
 
         // remove old active highlights and set new highlight
@@ -134,7 +136,7 @@ L.Control.Sidebar = L.Control.extend({
                 L.DomUtil.removeClass(child, 'active');
         }
 
-        this.fire('content', { id: id });
+        this.fire('tab-opened', { id: id });
 
         // open sidebar (if necessary)
         if (L.DomUtil.hasClass(this._sidebar, 'collapsed')) {
@@ -152,8 +154,10 @@ L.Control.Sidebar = L.Control.extend({
         // remove old active highlights
         for (var i = this._tabitems.length - 1; i >= 0; i--) {
             var child = this._tabitems[i];
-            if (L.DomUtil.hasClass(child, 'active'))
+            if (L.DomUtil.hasClass(child, 'active')) {
                 L.DomUtil.removeClass(child, 'active');
+                this.fire('tab-closed', {id: child.id });
+            }
         }
 
         // close sidebar


### PR DESCRIPTION
adding a 'tab-closed' event to match the 'content' event and then renamed the 'content' event to 'tab-opening'.

Now when a user changes tabs on the sidebar the tab closing event fires letting listeners know which tab is closing, before the dom fires the 'tab-opening' event to let users know which tab is opening.  This is useful for adding and removing event listeners which are attached to a particular tab.