### PR TITLE
Allow custom actions on `.sidebar-button` links.

### DIFF
--- a/examples/gmaps.html
+++ b/examples/gmaps.html
@@ -34,6 +34,7 @@
                 <li><a href="#home" role="tab"><i class="fa fa-bars"></i></a></li>
                 <li><a href="#profile" role="tab"><i class="fa fa-user"></i></a></li>
                 <li class="disabled"><a href="#messages" role="tab"><i class="fa fa-envelope"></i></a></li>
+                <li class="sidebar-button"><a href="#" onclick="alert('do something useful now :)'); return false;"><i class="fa fa-comment"></i></a></li>
             </ul>
 
             <ul role="tablist">

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,6 +36,7 @@
                 <li><a href="#home" role="tab"><i class="fa fa-bars"></i></a></li>
                 <li><a href="#profile" role="tab"><i class="fa fa-user"></i></a></li>
                 <li class="disabled"><a href="#messages" role="tab"><i class="fa fa-envelope"></i></a></li>
+                <li class="sidebar-button"><a href="#" onclick="alert('do something useful now :)'); return false;"><i class="fa fa-comment"></i></a></li>
             </ul>
 
             <ul role="tablist">

--- a/examples/ol2.html
+++ b/examples/ol2.html
@@ -35,6 +35,7 @@
                 <li><a href="#home" role="tab"><i class="fa fa-bars"></i></a></li>
                 <li><a href="#profile" role="tab"><i class="fa fa-user"></i></a></li>
                 <li class="disabled"><a href="#messages" role="tab"><i class="fa fa-envelope"></i></a></li>
+                <li class="sidebar-button"><a href="#" onclick="alert('do something useful now :)'); return false;"><i class="fa fa-comment"></i></a></li>
             </ul>
 
             <ul role="tablist">

--- a/examples/ol3.html
+++ b/examples/ol3.html
@@ -36,6 +36,7 @@
                 <li><a href="#home" role="tab"><i class="fa fa-bars"></i></a></li>
                 <li><a href="#profile" role="tab"><i class="fa fa-user"></i></a></li>
                 <li class="disabled"><a href="#messages" role="tab"><i class="fa fa-envelope"></i></a></li>
+                <li class="sidebar-button"><a href="#" onclick="alert('do something useful now :)'); return false;"><i class="fa fa-comment"></i></a></li>
             </ul>
 
             <ul role="tablist">

--- a/js/jquery-sidebar.js
+++ b/js/jquery-sidebar.js
@@ -20,13 +20,15 @@ $.fn.sidebar = function(options) {
     $sidebar.addClass('sidebar-' + options.position);
 
     $tabs.children('li').children('a').on('click', function(e) {
-        e.preventDefault();
         var $tab = $(this).closest('li');
+        if (!$tab.hasClass('sidebar-button')) {
+            e.preventDefault();
 
-        if ($tab.hasClass('active'))
-            $sidebar.close();
-        else if (!$tab.hasClass('disabled'))
-            $sidebar.open(this.hash.slice(1), $tab);
+            if ($tab.hasClass('active'))
+                $sidebar.close();
+            else if (!$tab.hasClass('disabled'))
+                $sidebar.open(this.hash.slice(1), $tab);
+        }
     });
 
     $sidebar.find('.sidebar-close').on('click', function() {

--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -73,7 +73,6 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
         for (i = this._tabitems.length - 1; i >= 0; i--) {
             child = this._tabitems[i];
             L.DomEvent
-                .on(child.querySelector('a'), 'click', L.DomEvent.preventDefault )
                 .on(child.querySelector('a'), 'click', this._onClick, child);
         }
 
@@ -169,11 +168,16 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
     /**
      * @private
      */
-    _onClick: function() {
-        if (L.DomUtil.hasClass(this, 'active'))
-            this._sidebar.close();
-        else if (!L.DomUtil.hasClass(this, 'disabled'))
-            this._sidebar.open(this.querySelector('a').hash.slice(1));
+    _onClick: function(e) {
+        if (!L.DomUtil.hasClass(this, 'sidebar-button')) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (L.DomUtil.hasClass(this, 'active')) {
+                this._sidebar.close();
+            } else if (!L.DomUtil.hasClass(this, 'disabled') {
+                this._sidebar.open(this.querySelector('a').hash.slice(1));
+            }
+        }
     },
 
     /**

--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -174,7 +174,7 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
             e.stopPropagation();
             if (L.DomUtil.hasClass(this, 'active')) {
                 this._sidebar.close();
-            } else if (!L.DomUtil.hasClass(this, 'disabled') {
+            } else if (!L.DomUtil.hasClass(this, 'disabled')) {
                 this._sidebar.open(this.querySelector('a').hash.slice(1));
             }
         }


### PR DESCRIPTION
Not sure if this is something you would consider, but it seemed logical in our use case, instead of scattering buttons all over the map, or adding extra button-bars, why not allow to add buttons to the sidebar, that would do a custom action, instead of opening a pane. 

The change in itself is pretty small: I removed the prevention of default, and postponed till the click-handler itself, and let it check for the classes. A user still has to attach her own click-event to her custom button, but at least now that is possible.

So in short: a `li.sidebar-button` will not be handled by the click-handler, allowing the sidebar to 
contain custom buttons with custom actions.

This is working code, but I understand you would need something more to merge it: I would be happy to provide an example, add some documentation, and adapt the jquery-code to have the same feature, but I just wanted to check if this is something you would even consider. 
