### PR TITLE
renaming removeFrom to remove

### DIFF
--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -86,8 +86,8 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
     },
     
     /**
-     * @deprecated - Please use remove() instead of removeFrom(), as of Leaflet 0.8-dev, the removeFrom() with remove()
-     * Remove this sidebar from the map.
+     * @deprecated - Please use remove() instead of removeFrom(), as of Leaflet 0.8-dev, the removeFrom() has been replaced with remove()
+     * Removes this sidebar from the map.
      * @param {L.Map} map
      * @returns {Sidebar}
      */

--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -91,7 +91,7 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
      * @param {L.Map} map
      * @returns {Sidebar}
      */
-    removeFrom: function (map) {
+    remove: function (map) {
         var i, child;
 
         this._map = null;

--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -84,6 +84,17 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
 
         return this;
     },
+    
+    /**
+     * @deprecated - Please use remove() instead of removeFrom(), as of Leaflet 0.8-dev, the removeFrom() with remove()
+     * Remove this sidebar from the map.
+     * @param {L.Map} map
+     * @returns {Sidebar}
+     */
+     removeFrom: function(map) {
+         console.log('removeFrom() has been deprecated, please use remove() instead as support for this function will be ending soon.');
+         this.remove(map);
+     },
 
     /**
      * Remove this sidebar from the map.


### PR DESCRIPTION
This change renames the `removeFrom` function to `remove` keeping this plugin inline leaflet.

See here for information on when leaflet changed their controls removal function from `removeFrom` to just `remove`: https://github.com/Leaflet/Leaflet/commit/eec19a441bc56e2c6db0dedc1719932464523cf0