### PR TITLE
Change source due to ol.source.MapQuest removal since 3.17 version

### DIFF
--- a/examples/ol3.html
+++ b/examples/ol3.html
@@ -89,7 +89,7 @@
             target: 'map',
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.MapQuest({layer: 'sat'})
+                    source: new ol.source.OSM()
                 })
             ],
             view: new ol.View({


### PR DESCRIPTION
Sample for OpenLayers 3 e.g http://turbo87.github.io/sidebar-v2/examples/ol3.html was broken. It's a simple fix for it.
See https://github.com/openlayers/ol3/issues/5484 to learn about the removal