### PR TITLE
Sidebar toolbar buttons/links

### DIFF
--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -72,9 +72,13 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
 
         for (i = this._tabitems.length - 1; i >= 0; i--) {
             child = this._tabitems[i];
-            L.DomEvent
-                .on(child.querySelector('a'), 'click', L.DomEvent.preventDefault )
-                .on(child.querySelector('a'), 'click', this._onClick, child);
+            var sub = child.querySelector('a');
+            if (sub.hasAttribute('href') && sub.getAttribute('href').slice(0,1) == '#') {
+                L.DomEvent
+                    .on(sub, 'click', L.DomEvent.preventDefault )
+                    .on(sub, 'click', this._onClick, child);
+            }
+            
         }
 
         for (i = this._closeButtons.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Updated to allow non-expanding links in sidebar. Useful if you want a direct toolbar button in the list. To use, just ditch the href='#something' and use a non hash tag, or a click event. 

```html
<div class="sidebar-tabs">
            <ul role="tablist">
                <li><a href="#menu" role="tab"><i class="fa fa-bars"></i></a></li>
                <li><a href="#edit" role="tab"><i class="fa fa-plus"></i></a></li>
<!-- onclick example -->
                <li><a role="tab" onClick="alert('bookmark!');"><i class="fa fa-bookmark"></i></a></li>
<!-- link example -->
                <li><a href="/" role="tab"><i class="fa fa-home"></i></a></li>
            </ul>
</div>
```