### PR TITLE
add type definition for leaflet-sidebar

### DIFF
--- a/typescript/leaflet-sidebar.d.ts
+++ b/typescript/leaflet-sidebar.d.ts
@@ -1,0 +1,26 @@
+/// <reference types="leaflet" />
+
+declare namespace L {
+
+  namespace Control {
+
+    interface SidebarOptions {
+      position: string;
+    }
+
+    class Sidebar extends Control {
+      constructor(id: string, options?: SidebarOptions);
+      options: Control.ControlOptions;
+      addTo(map: L.Map): this;
+      remove(map: L.Map): this;
+      open(id: string): this;
+      close(): this;
+    }
+
+  }
+
+  namespace control {
+    function sidebar(id: string, options?: Control.SidebarOptions): L.Control.Sidebar;
+  }
+
+}


### PR DESCRIPTION
Finish issue #110. By referencing this file, TypeScript developers are able to leaflet-sidebar in their leaflet project :-)