### PR TITLE
Add preventDefault to OpenLayers version

### DIFF
--- a/js/ol3-sidebar.js
+++ b/js/ol3-sidebar.js
@@ -111,7 +111,8 @@ ol.control.Sidebar.prototype.close = function() {
     return this;
 };
 
-ol.control.Sidebar.prototype._onClick = function() {
+ol.control.Sidebar.prototype._onClick = function(evt) {
+    evt.preventDefault();
     if (this.classList.contains('active')) {
         this._sidebar.close();
     } else if (!this.classList.contains('disabled')) {


### PR DESCRIPTION
The links used as buttons to open/close the sidebar act as real links, navigating (vertically) to the selected element. This is almost always undesirable. This patch overrides this behaviour.

This is done [already](https://github.com/Turbo87/sidebar-v2/search?utf8=%E2%9C%93&q=preventDefault&type=) in the leaflet/jquery versions.
