### PR TITLE
Ol5 sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 
 dist
 build
+
+.cache
+package-lock.json

--- a/examples/ol5.html
+++ b/examples/ol5.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.2.0/css/ol.css" type="text/css">
+
+    <link rel="stylesheet" href="../css/ol3-sidebar.css" />
 
     <style>
         body {

--- a/examples/ol5.html
+++ b/examples/ol5.html
@@ -78,6 +78,8 @@
 
     <a href="https://github.com/Turbo87/sidebar-v2/"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
+    <script src="https://openlayers.org/en/v5.1.3/build/ol.js"></script>
+    <script src="../dist/ol5-sidebar.js"></script>
     <script src="./ol5.js"></script>
 </body>
 </html>

--- a/examples/ol5.html
+++ b/examples/ol5.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>sidebar-v2 example</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+
+    <style>
+        body {
+            padding: 0;
+            margin: 0;
+            overflow: hidden;
+        }
+
+        html, body, #map {
+            height: 100%;
+            font: 10pt "Helvetica Neue", Arial, Helvetica, sans-serif;
+        }
+
+        .lorem {
+            font-style: italic;
+            color: #AAA;
+        }
+    </style>
+</head>
+<body>
+    <div id="sidebar" class="sidebar collapsed">
+        <!-- Nav tabs -->
+        <div class="sidebar-tabs">
+            <ul role="tablist">
+                <li><a href="#home" role="tab"><i class="fa fa-bars"></i></a></li>
+                <li><a href="#profile" role="tab"><i class="fa fa-user"></i></a></li>
+                <li class="disabled"><a href="#messages" role="tab"><i class="fa fa-envelope"></i></a></li>
+                <li><a href="https://github.com/Turbo87/sidebar-v2" role="tab" target="_blank"><i class="fa fa-github"></i></a></li>
+            </ul>
+
+            <ul role="tablist">
+                <li><a href="#settings" role="tab"><i class="fa fa-gear"></i></a></li>
+            </ul>
+        </div>
+
+        <!-- Tab panes -->
+        <div class="sidebar-content">
+            <div class="sidebar-pane" id="home">
+                <h1 class="sidebar-header">
+                    sidebar-v2
+                    <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
+                </h1>
+
+                <p>A responsive sidebar for mapping libraries like <a href="http://leafletjs.com/">Leaflet</a> or <a href="http://openlayers.org/">OpenLayers</a>.</p>
+
+                <p class="lorem">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+
+                <p class="lorem">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+
+                <p class="lorem">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+
+                <p class="lorem">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+            </div>
+
+            <div class="sidebar-pane" id="profile">
+                <h1 class="sidebar-header">Profile<span class="sidebar-close"><i class="fa fa-caret-left"></i></span></h1>
+            </div>
+
+            <div class="sidebar-pane" id="messages">
+                <h1 class="sidebar-header">Messages<span class="sidebar-close"><i class="fa fa-caret-left"></i></span></h1>
+            </div>
+
+            <div class="sidebar-pane" id="settings">
+                <h1 class="sidebar-header">Settings<span class="sidebar-close"><i class="fa fa-caret-left"></i></span></h1>
+            </div>
+        </div>
+    </div>
+
+    <div id="map" class="sidebar-map"></div>
+
+    <a href="https://github.com/Turbo87/sidebar-v2/"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+
+    <script src="./ol5.js"></script>
+</body>
+</html>

--- a/examples/ol5.js
+++ b/examples/ol5.js
@@ -1,23 +1,12 @@
-// CSS imports
-import 'ol/ol.css';
-import '../css/ol3-sidebar.css';
-
-// JS imports
-import Map from 'ol/Map';
-import View from 'ol/View';
-import LayerTile from 'ol/layer/Tile';
-import SourceOSM from 'ol/source/OSM';
-import { transform } from 'ol/proj.js';
-
-var map = new Map({
+var map = new ol.Map({
     layers: [
-        new LayerTile({
-            source: new SourceOSM()
+        new ol.layer.Tile({
+            source: new ol.source.OSM()
         })
     ],
     target: 'map',
-    view: new View({
-        center: transform([7, 51.2], 'EPSG:4326', 'EPSG:3857'),
+    view: new ol.View({
+        center: ol.proj.transform([7, 51.2], 'EPSG:4326', 'EPSG:3857'),
         zoom: 4,
     })
 });

--- a/examples/ol5.js
+++ b/examples/ol5.js
@@ -1,5 +1,6 @@
 // CSS imports
 import 'ol/ol.css';
+import '../css/ol3-sidebar.css';
 
 // JS imports
 import Map from 'ol/Map';
@@ -7,11 +8,9 @@ import View from 'ol/View';
 import LayerTile from 'ol/layer/Tile';
 import SourceOSM from 'ol/source/OSM';
 import { transform } from 'ol/proj.js';
+import { defaults as defaultControls } from 'ol/control.js';
 import { inherits } from 'ol/util.js';
 import Control from 'ol/control/Control';
-import { defaults as defaultControls } from 'ol/control.js';
-
-import { Sidebar } from '../js/ol5-sidebar';
 
 /**
  * Define a namespace for the application.
@@ -19,7 +18,129 @@ import { Sidebar } from '../js/ol5-sidebar';
 window.app = {};
 var app = window.app;
 
+app.Sidebar = function(settings) {
+    var defaults = {
+        element: null,
+        position: 'left'
+    }, i, child;
+
+    this._options = Object.assign({}, defaults, settings);
+
+    Control.call(this, {
+        element: document.getElementById(this._options.element),
+        target: this._options.target
+    });
+
+    // Attach .sidebar-left/right class
+    this.element.classList.add('sidebar-' + this._options.position);
+
+    // Find sidebar > div.sidebar-content
+    for (i = this.element.children.length - 1; i >= 0; i--) {
+        child = this.element.children[i];
+        if (child.tagName === 'DIV' &&
+                child.classList.contains('sidebar-content')) {
+            this._container = child;
+        }
+    }
+
+    // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
+    this._tabitems = this.element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
+    for (i = this._tabitems.length - 1; i >= 0; i--) {
+        this._tabitems[i]._sidebar = this;
+    }
+
+    // Find sidebar > div.sidebar-content > div.sidebar-pane
+    this._panes = [];
+    this._closeButtons = [];
+    for (i = this._container.children.length - 1; i >= 0; i--) {
+        child = this._container.children[i];
+        if (child.tagName == 'DIV' &&
+                child.classList.contains('sidebar-pane')) {
+            this._panes.push(child);
+
+            var closeButtons = child.querySelectorAll('.sidebar-close');
+            for (var j = 0, len = closeButtons.length; j < len; j++) {
+                this._closeButtons.push(closeButtons[j]);
+            }
+        }
+    }
+};
+
 inherits(app.Sidebar, Control);
+
+app.Sidebar.prototype.setMap = function(map) {
+    var i, child;
+
+    for (i = this._tabitems.length - 1; i >= 0; i--) {
+        child = this._tabitems[i];
+        var sub = child.querySelector('a');
+        if (sub.hasAttribute('href') && sub.getAttribute('href').slice(0,1) == '#') {
+            sub.onclick = this._onClick.bind(child);
+        }
+    }
+
+    for (i = this._closeButtons.length - 1; i >= 0; i--) {
+        child = this._closeButtons[i];
+        child.onclick = this._onCloseClick.bind(this);
+    }
+};
+
+app.Sidebar.prototype.open = function(id) {
+    var i, child;
+
+    // hide old active contents and show new content
+    for (i = this._panes.length - 1; i >= 0; i--) {
+        child = this._panes[i];
+        if (child.id == id)
+            child.classList.add('active');
+        else if (child.classList.contains('active'))
+            child.classList.remove('active');
+    }
+
+    // remove old active highlights and set new highlight
+    for (i = this._tabitems.length - 1; i >= 0; i--) {
+        child = this._tabitems[i];
+        if (child.querySelector('a').hash == '#' + id)
+            child.classList.add('active');
+        else if (child.classList.contains('active'))
+            child.classList.remove('active');
+    }
+
+    // open sidebar (if necessary)
+    if (this.element.classList.contains('collapsed')) {
+        this.element.classList.remove('collapsed');
+    }
+
+    return this;
+};
+
+app.Sidebar.prototype.close = function() {
+    // remove old active highlights
+    for (var i = this._tabitems.length - 1; i >= 0; i--) {
+        var child = this._tabitems[i];
+        if (child.classList.contains('active'))
+            child.classList.remove('active');
+    }
+
+    // close sidebar
+    if (!this.element.classList.contains('collapsed')) {
+        this.element.classList.add('collapsed');
+    }
+
+    return this;
+};
+
+app.Sidebar.prototype._onClick = function() {
+    if (this.classList.contains('active')) {
+        this._sidebar.close();
+    } else if (!this.classList.contains('disabled')) {
+        this._sidebar.open(this.querySelector('a').hash.slice(1));
+    }
+};
+
+app.Sidebar.prototype._onCloseClick = function() {
+    this.close();
+};
 
 var map = new Map({
     controls: defaultControls({
@@ -30,8 +151,8 @@ var map = new Map({
         new app.Sidebar({ element: 'sidebar', position: 'left' })
     ]),
     layers: [
-        new TileLayer({
-            source: new OSM()
+        new LayerTile({
+            source: new SourceOSM()
         })
     ],
     target: 'map',

--- a/examples/ol5.js
+++ b/examples/ol5.js
@@ -8,148 +8,8 @@ import View from 'ol/View';
 import LayerTile from 'ol/layer/Tile';
 import SourceOSM from 'ol/source/OSM';
 import { transform } from 'ol/proj.js';
-import { defaults as defaultControls } from 'ol/control.js';
-import { inherits } from 'ol/util.js';
-import Control from 'ol/control/Control';
-
-/**
- * Define a namespace for the application.
- */
-window.app = {};
-var app = window.app;
-
-app.Sidebar = function(settings) {
-    var defaults = {
-        element: null,
-        position: 'left'
-    }, i, child;
-
-    this._options = Object.assign({}, defaults, settings);
-
-    Control.call(this, {
-        element: document.getElementById(this._options.element),
-        target: this._options.target
-    });
-
-    // Attach .sidebar-left/right class
-    this.element.classList.add('sidebar-' + this._options.position);
-
-    // Find sidebar > div.sidebar-content
-    for (i = this.element.children.length - 1; i >= 0; i--) {
-        child = this.element.children[i];
-        if (child.tagName === 'DIV' &&
-                child.classList.contains('sidebar-content')) {
-            this._container = child;
-        }
-    }
-
-    // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
-    this._tabitems = this.element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
-    for (i = this._tabitems.length - 1; i >= 0; i--) {
-        this._tabitems[i]._sidebar = this;
-    }
-
-    // Find sidebar > div.sidebar-content > div.sidebar-pane
-    this._panes = [];
-    this._closeButtons = [];
-    for (i = this._container.children.length - 1; i >= 0; i--) {
-        child = this._container.children[i];
-        if (child.tagName == 'DIV' &&
-                child.classList.contains('sidebar-pane')) {
-            this._panes.push(child);
-
-            var closeButtons = child.querySelectorAll('.sidebar-close');
-            for (var j = 0, len = closeButtons.length; j < len; j++) {
-                this._closeButtons.push(closeButtons[j]);
-            }
-        }
-    }
-};
-
-inherits(app.Sidebar, Control);
-
-app.Sidebar.prototype.setMap = function(map) {
-    var i, child;
-
-    for (i = this._tabitems.length - 1; i >= 0; i--) {
-        child = this._tabitems[i];
-        var sub = child.querySelector('a');
-        if (sub.hasAttribute('href') && sub.getAttribute('href').slice(0,1) == '#') {
-            sub.onclick = this._onClick.bind(child);
-        }
-    }
-
-    for (i = this._closeButtons.length - 1; i >= 0; i--) {
-        child = this._closeButtons[i];
-        child.onclick = this._onCloseClick.bind(this);
-    }
-};
-
-app.Sidebar.prototype.open = function(id) {
-    var i, child;
-
-    // hide old active contents and show new content
-    for (i = this._panes.length - 1; i >= 0; i--) {
-        child = this._panes[i];
-        if (child.id == id)
-            child.classList.add('active');
-        else if (child.classList.contains('active'))
-            child.classList.remove('active');
-    }
-
-    // remove old active highlights and set new highlight
-    for (i = this._tabitems.length - 1; i >= 0; i--) {
-        child = this._tabitems[i];
-        if (child.querySelector('a').hash == '#' + id)
-            child.classList.add('active');
-        else if (child.classList.contains('active'))
-            child.classList.remove('active');
-    }
-
-    // open sidebar (if necessary)
-    if (this.element.classList.contains('collapsed')) {
-        this.element.classList.remove('collapsed');
-    }
-
-    return this;
-};
-
-app.Sidebar.prototype.close = function() {
-    // remove old active highlights
-    for (var i = this._tabitems.length - 1; i >= 0; i--) {
-        var child = this._tabitems[i];
-        if (child.classList.contains('active'))
-            child.classList.remove('active');
-    }
-
-    // close sidebar
-    if (!this.element.classList.contains('collapsed')) {
-        this.element.classList.add('collapsed');
-    }
-
-    return this;
-};
-
-app.Sidebar.prototype._onClick = function() {
-    if (this.classList.contains('active')) {
-        this._sidebar.close();
-    } else if (!this.classList.contains('disabled')) {
-        this._sidebar.open(this.querySelector('a').hash.slice(1));
-    }
-};
-
-app.Sidebar.prototype._onCloseClick = function() {
-    this.close();
-};
 
 var map = new Map({
-    controls: defaultControls({
-        attributionOptions: {
-            collapsible: false
-        }
-    }).extend([
-        new app.Sidebar({ element: 'sidebar', position: 'left' })
-    ]),
     layers: [
         new LayerTile({
             source: new SourceOSM()
@@ -161,3 +21,7 @@ var map = new Map({
         zoom: 4,
     })
 });
+
+var sidebar = new ol.control.Sidebar({ element: 'sidebar', position: 'left' });
+
+map.addControl(sidebar);

--- a/examples/ol5.js
+++ b/examples/ol5.js
@@ -1,0 +1,42 @@
+// CSS imports
+import 'ol/ol.css';
+
+// JS imports
+import Map from 'ol/Map';
+import View from 'ol/View';
+import LayerTile from 'ol/layer/Tile';
+import SourceOSM from 'ol/source/OSM';
+import { transform } from 'ol/proj.js';
+import { inherits } from 'ol/util.js';
+import Control from 'ol/control/Control';
+import { defaults as defaultControls } from 'ol/control.js';
+
+import { Sidebar } from '../js/ol5-sidebar';
+
+/**
+ * Define a namespace for the application.
+ */
+window.app = {};
+var app = window.app;
+
+inherits(app.Sidebar, Control);
+
+var map = new Map({
+    controls: defaultControls({
+        attributionOptions: {
+            collapsible: false
+        }
+    }).extend([
+        new app.Sidebar({ element: 'sidebar', position: 'left' })
+    ]),
+    layers: [
+        new TileLayer({
+            source: new OSM()
+        })
+    ],
+    target: 'map',
+    view: new View({
+        center: transform([7, 51.2], 'EPSG:4326', 'EPSG:3857'),
+        zoom: 4,
+    })
+});

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -12,17 +12,19 @@ export default class Sidebar extends Control {
 
         var options = Object.assign({}, defaults, opt_options);
 
+        var element = document.getElementById(options.element);
+
         super({
-            element: document.getElementById(options.element),
+            element: element,
             target: options.target
         });
 
         // Attach .sidebar-left/right class
-        this.element.classList.add('sidebar-' + this.position);
+        element.classList.add('sidebar-' + options.position);
 
         // Find sidebar > div.sidebar-content
-        for (i = this.element.children.length - 1; i >= 0; i--) {
-            child = this.element.children[i];
+        for (i = element.children.length - 1; i >= 0; i--) {
+            child = element.children[i];
             if (child.tagName === 'DIV' &&
                     child.classList.contains('sidebar-content')) {
                 this._container = child;
@@ -30,7 +32,7 @@ export default class Sidebar extends Control {
         }
 
         // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
-        this._tabitems = this.element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
+        this._tabitems = element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
         for (i = this._tabitems.length - 1; i >= 0; i--) {
             this._tabitems[i]._sidebar = this;
         }
@@ -57,7 +59,6 @@ export default class Sidebar extends Control {
     * @param {ol.Map} map The map instance.
     */
     setMap(map) {
-		super.setMap(map);
         var i, child;
 
         for (i = this._tabitems.length - 1; i >= 0; i--) {
@@ -119,11 +120,12 @@ export default class Sidebar extends Control {
         return this;
     };
 
-    _onClick() {
+    _onClick(evt) {
+        evt.preventDefault();
         if (this.classList.contains('active')) {
             this._sidebar.close();
         } else if (!this.classList.contains('disabled')) {
-            Sidebar.open(this.querySelector('a').hash.slice(1));
+            this._sidebar.open(this.querySelector('a').hash.slice(1));
         }
     };
 

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -119,12 +119,12 @@ export default class Sidebar extends Control {
         if (this.classList.contains('active')) {
             this._sidebar.close();
         } else if (!this.classList.contains('disabled')) {
-            this._sidebar.open(this.querySelector('a').hash.slice(1));
+            Sidebar.open(this.querySelector('a').hash.slice(1));
         }
     };
 
     _onCloseClick() {
-        this.close();
+        Sidebar.close();
     };
 }
 

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -1,0 +1,130 @@
+// CSS imports
+import 'ol/ol.css';
+import '../css/ol3-sidebar.css';
+
+/**
+* Define a namespace for the application.
+*/
+
+export default function Sidebar(settings) {
+
+    var defaults = {
+        element: null,
+        position: 'left'
+    }, i, child;
+
+    this._options = Object.assign({}, defaults, settings);
+
+    Control.call(this, {
+        element: document.getElementById(this._options.element),
+        target: this._options.target
+    });
+
+    // Attach .sidebar-left/right class
+    this.element.classList.add('sidebar-' + this._options.position);
+
+    // Find sidebar > div.sidebar-content
+    for (i = this.element.children.length - 1; i >= 0; i--) {
+        child = this.element.children[i];
+        if (child.tagName === 'DIV' &&
+                child.classList.contains('sidebar-content')) {
+            this._container = child;
+        }
+    }
+
+    // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
+    this._tabitems = this.element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
+    for (i = this._tabitems.length - 1; i >= 0; i--) {
+        this._tabitems[i]._sidebar = this;
+    }
+
+    // Find sidebar > div.sidebar-content > div.sidebar-pane
+    this._panes = [];
+    this._closeButtons = [];
+    for (i = this._container.children.length - 1; i >= 0; i--) {
+        child = this._container.children[i];
+        if (child.tagName == 'DIV' &&
+                child.classList.contains('sidebar-pane')) {
+            this._panes.push(child);
+
+            var closeButtons = child.querySelectorAll('.sidebar-close');
+            for (var j = 0, len = closeButtons.length; j < len; j++) {
+                this._closeButtons.push(closeButtons[j]);
+            }
+        }
+    }
+};
+
+Sidebar.prototype.setMap = function(map) {
+    var i, child;
+
+    for (i = this._tabitems.length - 1; i >= 0; i--) {
+        child = this._tabitems[i];
+        var sub = child.querySelector('a');
+        if (sub.hasAttribute('href') && sub.getAttribute('href').slice(0,1) == '#') {
+            sub.onclick = this._onClick.bind(child);
+        }
+    }
+
+    for (i = this._closeButtons.length - 1; i >= 0; i--) {
+        child = this._closeButtons[i];
+        child.onclick = this._onCloseClick.bind(this);
+    }
+};
+
+Sidebar.prototype.open = function(id) {
+    var i, child;
+
+    // hide old active contents and show new content
+    for (i = this._panes.length - 1; i >= 0; i--) {
+        child = this._panes[i];
+        if (child.id == id)
+            child.classList.add('active');
+        else if (child.classList.contains('active'))
+            child.classList.remove('active');
+    }
+
+    // remove old active highlights and set new highlight
+    for (i = this._tabitems.length - 1; i >= 0; i--) {
+        child = this._tabitems[i];
+        if (child.querySelector('a').hash == '#' + id)
+            child.classList.add('active');
+        else if (child.classList.contains('active'))
+            child.classList.remove('active');
+    }
+
+    // open sidebar (if necessary)
+    if (this.element.classList.contains('collapsed')) {
+        this.element.classList.remove('collapsed');
+    }
+
+    return this;
+};
+
+Sidebar.prototype.close = function() {
+    // remove old active highlights
+    for (var i = this._tabitems.length - 1; i >= 0; i--) {
+        var child = this._tabitems[i];
+        if (child.classList.contains('active'))
+            child.classList.remove('active');
+    }
+
+    // close sidebar
+    if (!this.element.classList.contains('collapsed')) {
+        this.element.classList.add('collapsed');
+    }
+
+    return this;
+};
+
+Sidebar.prototype._onClick = function() {
+    if (this.classList.contains('active')) {
+        this._sidebar.close();
+    } else if (!this.classList.contains('disabled')) {
+        this._sidebar.open(this.querySelector('a').hash.slice(1));
+    }
+};
+
+Sidebar.prototype._onCloseClick = function() {
+    this.close();
+};

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -4,22 +4,25 @@ import Control from 'ol/control/Control';
 export default class Sidebar extends Control {
 
     constructor(opt_options) {
-        var options = opt_options || {};
 
-        var position = options.position ?
-            options.position : 'left';
+        var defaults = {
+            element: null,
+            position: 'left'
+        }, i, child;
 
-        var element = options.element ?
-            options.element : null;
+        var options = Object.assign({}, defaults, opt_options);
 
-        super({ element: document.getElementById(options.element), target: options.target});
+        super({
+            element: document.getElementById(options.element),
+            target: options.target
+        });
 
         // Attach .sidebar-left/right class
-        element.classList.add('sidebar-' + position);
+        this.element.classList.add('sidebar-' + this.position);
 
         // Find sidebar > div.sidebar-content
-        for (i = element.children.length - 1; i >= 0; i--) {
-            child = element.children[i];
+        for (i = this.element.children.length - 1; i >= 0; i--) {
+            child = this.element.children[i];
             if (child.tagName === 'DIV' &&
                     child.classList.contains('sidebar-content')) {
                 this._container = child;
@@ -27,7 +30,7 @@ export default class Sidebar extends Control {
         }
 
         // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
-        this._tabitems = element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
+        this._tabitems = this.element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
         for (i = this._tabitems.length - 1; i >= 0; i--) {
             this._tabitems[i]._sidebar = this;
         }

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -54,6 +54,7 @@ export default class Sidebar extends Control {
     * @param {ol.Map} map The map instance.
     */
     setMap(map) {
+		super.setMap(map);
         var i, child;
 
         for (i = this._tabitems.length - 1; i >= 0; i--) {

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -2,9 +2,9 @@
 import 'ol/ol.css';
 import '../css/ol3-sidebar.css';
 
-/**
-* Define a namespace for the application.
-*/
+// JS imports
+import { inherits } from 'ol/util.js';
+import Control from 'ol/control/Control';
 
 export default function Sidebar(settings) {
 
@@ -54,6 +54,8 @@ export default function Sidebar(settings) {
         }
     }
 };
+
+inherits(Sidebar, Control);
 
 Sidebar.prototype.setMap = function(map) {
     var i, child;

--- a/js/ol5-sidebar.js
+++ b/js/ol5-sidebar.js
@@ -1,132 +1,135 @@
-// CSS imports
-import 'ol/ol.css';
-import '../css/ol3-sidebar.css';
-
 // JS imports
-import { inherits } from 'ol/util.js';
 import Control from 'ol/control/Control';
 
-export default function Sidebar(settings) {
+export default class Sidebar extends Control {
 
-    var defaults = {
-        element: null,
-        position: 'left'
-    }, i, child;
+    constructor(opt_options) {
+        var options = opt_options || {};
 
-    this._options = Object.assign({}, defaults, settings);
+        var position = options.position ?
+            options.position : 'left';
 
-    Control.call(this, {
-        element: document.getElementById(this._options.element),
-        target: this._options.target
-    });
+        var element = options.element ?
+            options.element : null;
 
-    // Attach .sidebar-left/right class
-    this.element.classList.add('sidebar-' + this._options.position);
+        super({ element: document.getElementById(options.element), target: options.target});
 
-    // Find sidebar > div.sidebar-content
-    for (i = this.element.children.length - 1; i >= 0; i--) {
-        child = this.element.children[i];
-        if (child.tagName === 'DIV' &&
-                child.classList.contains('sidebar-content')) {
-            this._container = child;
+        // Attach .sidebar-left/right class
+        element.classList.add('sidebar-' + position);
+
+        // Find sidebar > div.sidebar-content
+        for (i = element.children.length - 1; i >= 0; i--) {
+            child = element.children[i];
+            if (child.tagName === 'DIV' &&
+                    child.classList.contains('sidebar-content')) {
+                this._container = child;
+            }
         }
-    }
 
-    // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
-    this._tabitems = this.element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
-    for (i = this._tabitems.length - 1; i >= 0; i--) {
-        this._tabitems[i]._sidebar = this;
-    }
+        // Find sidebar ul.sidebar-tabs > li, sidebar .sidebar-tabs > ul > li
+        this._tabitems = element.querySelectorAll('ul.sidebar-tabs > li, .sidebar-tabs > ul > li');
+        for (i = this._tabitems.length - 1; i >= 0; i--) {
+            this._tabitems[i]._sidebar = this;
+        }
 
-    // Find sidebar > div.sidebar-content > div.sidebar-pane
-    this._panes = [];
-    this._closeButtons = [];
-    for (i = this._container.children.length - 1; i >= 0; i--) {
-        child = this._container.children[i];
-        if (child.tagName == 'DIV' &&
-                child.classList.contains('sidebar-pane')) {
-            this._panes.push(child);
+        // Find sidebar > div.sidebar-content > div.sidebar-pane
+        this._panes = [];
+        this._closeButtons = [];
+        for (i = this._container.children.length - 1; i >= 0; i--) {
+            child = this._container.children[i];
+            if (child.tagName == 'DIV' &&
+                    child.classList.contains('sidebar-pane')) {
+                this._panes.push(child);
 
-            var closeButtons = child.querySelectorAll('.sidebar-close');
-            for (var j = 0, len = closeButtons.length; j < len; j++) {
-                this._closeButtons.push(closeButtons[j]);
+                var closeButtons = child.querySelectorAll('.sidebar-close');
+                for (var j = 0, len = closeButtons.length; j < len; j++) {
+                    this._closeButtons.push(closeButtons[j]);
+                }
             }
         }
     }
-};
 
-inherits(Sidebar, Control);
+    /**
+    * Set the map instance the control is associated with.
+    * @param {ol.Map} map The map instance.
+    */
+    setMap(map) {
+        var i, child;
 
-Sidebar.prototype.setMap = function(map) {
-    var i, child;
-
-    for (i = this._tabitems.length - 1; i >= 0; i--) {
-        child = this._tabitems[i];
-        var sub = child.querySelector('a');
-        if (sub.hasAttribute('href') && sub.getAttribute('href').slice(0,1) == '#') {
-            sub.onclick = this._onClick.bind(child);
+        for (i = this._tabitems.length - 1; i >= 0; i--) {
+            child = this._tabitems[i];
+            var sub = child.querySelector('a');
+            if (sub.hasAttribute('href') && sub.getAttribute('href').slice(0,1) == '#') {
+                sub.onclick = this._onClick.bind(child);
+            }
         }
-    }
 
-    for (i = this._closeButtons.length - 1; i >= 0; i--) {
-        child = this._closeButtons[i];
-        child.onclick = this._onCloseClick.bind(this);
-    }
-};
+        for (i = this._closeButtons.length - 1; i >= 0; i--) {
+            child = this._closeButtons[i];
+            child.onclick = this._onCloseClick.bind(this);
+        }
+    };
 
-Sidebar.prototype.open = function(id) {
-    var i, child;
+    open(id) {
+        var i, child;
 
-    // hide old active contents and show new content
-    for (i = this._panes.length - 1; i >= 0; i--) {
-        child = this._panes[i];
-        if (child.id == id)
-            child.classList.add('active');
-        else if (child.classList.contains('active'))
-            child.classList.remove('active');
-    }
+        // hide old active contents and show new content
+        for (i = this._panes.length - 1; i >= 0; i--) {
+            child = this._panes[i];
+            if (child.id == id)
+                child.classList.add('active');
+            else if (child.classList.contains('active'))
+                child.classList.remove('active');
+        }
 
-    // remove old active highlights and set new highlight
-    for (i = this._tabitems.length - 1; i >= 0; i--) {
-        child = this._tabitems[i];
-        if (child.querySelector('a').hash == '#' + id)
-            child.classList.add('active');
-        else if (child.classList.contains('active'))
-            child.classList.remove('active');
-    }
+        // remove old active highlights and set new highlight
+        for (i = this._tabitems.length - 1; i >= 0; i--) {
+            child = this._tabitems[i];
+            if (child.querySelector('a').hash == '#' + id)
+                child.classList.add('active');
+            else if (child.classList.contains('active'))
+                child.classList.remove('active');
+        }
 
-    // open sidebar (if necessary)
-    if (this.element.classList.contains('collapsed')) {
-        this.element.classList.remove('collapsed');
-    }
+        // open sidebar (if necessary)
+        if (this.element.classList.contains('collapsed')) {
+            this.element.classList.remove('collapsed');
+        }
 
-    return this;
-};
+        return this;
+    };
 
-Sidebar.prototype.close = function() {
-    // remove old active highlights
-    for (var i = this._tabitems.length - 1; i >= 0; i--) {
-        var child = this._tabitems[i];
-        if (child.classList.contains('active'))
-            child.classList.remove('active');
-    }
+    close() {
+        // remove old active highlights
+        for (var i = this._tabitems.length - 1; i >= 0; i--) {
+            var child = this._tabitems[i];
+            if (child.classList.contains('active'))
+                child.classList.remove('active');
+        }
 
-    // close sidebar
-    if (!this.element.classList.contains('collapsed')) {
-        this.element.classList.add('collapsed');
-    }
+        // close sidebar
+        if (!this.element.classList.contains('collapsed')) {
+            this.element.classList.add('collapsed');
+        }
 
-    return this;
-};
+        return this;
+    };
 
-Sidebar.prototype._onClick = function() {
-    if (this.classList.contains('active')) {
-        this._sidebar.close();
-    } else if (!this.classList.contains('disabled')) {
-        this._sidebar.open(this.querySelector('a').hash.slice(1));
-    }
-};
+    _onClick() {
+        if (this.classList.contains('active')) {
+            this._sidebar.close();
+        } else if (!this.classList.contains('disabled')) {
+            this._sidebar.open(this.querySelector('a').hash.slice(1));
+        }
+    };
 
-Sidebar.prototype._onCloseClick = function() {
-    this.close();
-};
+    _onCloseClick() {
+        this.close();
+    };
+}
+
+// Expose Sidebar as ol.control.Sidebar if using a full build of
+// OpenLayers
+if (window.ol && window.ol.control) {
+    window.ol.control.Sidebar = Sidebar;
+}

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "scripts": {
     "test": "gulp lint",
     "start": "parcel ./examples/ol5.html",
-    "build": "parcel build --public-url ./ ./examples/ol5.html"
+    "build": "parcel build --public-url ./ ./js/ol5-sidebar.js"
   },
   "devDependencies": {
+    "cssnano": "^4.1.3",
     "gulp": "~3.9.1",
     "gulp-clean": "~0.3.1",
     "gulp-concat": "~2.6.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
     "type": "git",
     "url": "https://github.com/turbo87/sidebar-v2.git"
   },
+  "main": "./examples/ol5.js",
   "scripts": {
-    "test": "gulp lint"
+    "test": "gulp lint",
+    "start": "parcel ./examples/ol5.html",
+    "build": "parcel build --public-url ./ ./examples/ol5.html"
   },
   "devDependencies": {
     "gulp": "~3.9.1",
@@ -36,5 +39,8 @@
     "gulp-uglify": "~3.0.0",
     "gulp-zip": "~4.0.0",
     "jshint": "^2.9.5"
+  },
+  "dependencies": {
+    "ol": "^5.2.0"
   }
 }


### PR DESCRIPTION
This PR makes the sidebar compatible with version 5 of OpenLayers, addressing #143.

I don't know if it fits your desire/requirements, but I added:

- **js/ol-sidebar.js**: rewrite of the sidebar code as ES6 module

- **examples/ol5.js**: map creation and addition of the sidebar (don't know if you prefer to keep this in the HTML as the other examples

- **examples/ol5.html**: the HTML part. Here I included a full build of OL5, however one could also use specific imports.

I didn't include the **dist/ol5-sidebar.js** folder which the HTML `<script>` is pointing to. I created it using parcel via `npm run build`.

However, if you consider this PR useful and you'll need that file as well, I'll be happy to provide it.

I am open to any improvements/rework if you think it is a valuable addition to your project.

Thanks!