### PR TITLE
Remove unused `gulp-zip` functionality

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,10 +3,6 @@ var cleanCSS = require('gulp-clean-css');
 var sass = require('gulp-sass');
 var rename = require('gulp-rename');
 var uglify = require('gulp-uglify');
-var zip = require('gulp-zip');
-
-var pkg = require('./package.json');
-var basename = pkg.name + '-' + pkg.version;
 
 // SASS compilation
 gulp.task('sass', function() {
@@ -32,21 +28,6 @@ gulp.task('minify:css', gulp.series('sass', function() {
 }));
 
 gulp.task('minify', gulp.parallel('minify:js', 'minify:css'));
-
-// Package for distribution
-gulp.task('zip', gulp.series('minify', function() {
-  return gulp.src([
-    'README.md',
-    'LICENSE',
-    'css/*-sidebar.min.css',
-    'js/*-sidebar.min.js',
-  ])
-  .pipe(rename(function (path) {
-    path.dirname = '';
-  }))
-  .pipe(zip(basename + '.zip'))
-  .pipe(gulp.dest('dist'));
-}));
 
 // Watch JS + CSS Files
 gulp.task('watch', gulp.series('minify', function() {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gulp-rename": "~1.2.0",
     "gulp-sass": "^3.1.0",
     "gulp-uglify": "~3.0.0",
-    "gulp-zip": "~4.0.0",
     "stylelint": "^13.0.0",
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-scss": "^3.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,10 +583,6 @@ browserslist@^4.8.3:
     electron-to-chromium "^1.3.341"
     node-releases "^1.1.47"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-
 buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
@@ -1692,10 +1688,6 @@ get-stdin@^7.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -1936,7 +1928,7 @@ gulp-uglify@~3.0.0:
     uglify-js "^3.0.5"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@^3.0, gulp-util@^3.0.0:
+gulp-util@^3.0:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -1958,15 +1950,6 @@ gulp-util@^3.0, gulp-util@^3.0.0:
     replace-ext "0.0.1"
     through2 "^2.0.0"
     vinyl "^0.5.0"
-
-gulp-zip@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-zip/-/gulp-zip-4.0.0.tgz#1cefc08b4bf36df4b5b1e7c6b36ee55ebbe4a881"
-  dependencies:
-    get-stream "^3.0.0"
-    gulp-util "^3.0.0"
-    through2 "^2.0.1"
-    yazl "^2.1.0"
 
 gulp@~4.0.0:
   version "4.0.2"
@@ -5128,9 +5111,3 @@ yargs@^7.0.0, yargs@^7.1.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
-
-yazl@^2.1.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.2.tgz#14cb19083e1e25a70092c1588aabe0f4e4dd4d88"
-  dependencies:
-    buffer-crc32 "~0.2.3"


### PR DESCRIPTION
https://github.com/Turbo87/sidebar-v2/releases already has zip files and tarballs of the releases 🤷‍♂ 